### PR TITLE
standardize debug print output

### DIFF
--- a/global/handlers.lua
+++ b/global/handlers.lua
@@ -245,7 +245,8 @@ function HandlerDebug (init, tParams, args)
 	end
 	local s = string.format("%-21s : ", os.date ('%x %X') .. ms)
 
-	table.insert (output, 1, s .. '  -->')
+	table.insert (output, 1, s)
+	table.insert (output, 1, '-->')
 	table.insert (output, '<--')
 	output = table.concat (output, '\r\n')
 	print (output)

--- a/global/handlers.lua
+++ b/global/handlers.lua
@@ -216,19 +216,20 @@ function HandlerDebug (init, tParams, args)
 	end
 
 	local output = init
+	for k,v in pairs(output) do output[k] = "  " .. v end
 
 	if (type (tParams) == 'table' and next (tParams) ~= nil) then
-		table.insert (output, '----PARAMS----')
+		table.insert (output, '        ----PARAMS----')
 		for k, v in pairs (tParams) do
-			local line = tostring (k) .. ' = ' .. tostring (v)
+			local line = string.format("  %-20s = %s", tostring(k), tostring(v) )
 			table.insert (output, line)
 		end
 	end
 
 	if (type (args) == 'table' and next (args) ~= nil) then
-		table.insert (output, '----ARGS----')
+		table.insert (output, '        ----ARGS----')
 		for k, v in pairs (args) do
-			local line = tostring (k) .. ' = ' .. tostring (v)
+			local line = string.format("  %-20s = %s", tostring(k), tostring(v) )
 			table.insert (output, line)
 		end
 	end
@@ -242,9 +243,9 @@ function HandlerDebug (init, tParams, args)
 		t = os.time ()
 		ms = ''
 	end
-	local s = os.date ('%x %X') .. ms
+	local s = string.format("%-21s : ", os.date ('%x %X') .. ms)
 
-	table.insert (output, 1, '-->  ' .. s)
+	table.insert (output, 1, s .. '  -->')
 	table.insert (output, '<--')
 	output = table.concat (output, '\r\n')
 	print (output)

--- a/global/lib.lua
+++ b/global/lib.lua
@@ -157,7 +157,7 @@ function dbg (strDebugText, ...)
 			t = os.time ()
 			ms = ''
 		end
-		local s = os.date ('%x %X') .. ms .. ' : '
+		local s = string.format("%-21s : ", os.date ('%x %X') .. ms)
 
 		print (s .. (strDebugText or ''), ...)
 		C4:DebugLog (strDebugText)


### PR DESCRIPTION
This PR aims to clean up some of the various debug logging in the common libraries. The timestamp is now aligned for all lines (which sometimes changes with the ms addition) and adds padding for other multi-line debug outputs which cycle over various tables for better readability. 

Simple example: 

```

08/19/22 14:50:06.170 :   -->
  OnConnectionStatusChanged: 6993
        ----PARAMS----
  nPort                = 1900
  strStatus            = ONLINE
<--
08/19/22 14:50:06.171 :   -->
  OnConnectionStatusChanged: 6992
        ----PARAMS----
  nPort                = 1900
  strStatus            = ONLINE
<--
08/19/22 14:50:06.767 : Device status retrieved
08/19/22 14:50:07.534 : 1 device discovered...
08/19/22 14:50:07.536 :   -->
  OnPropertyChanged: Device Target
  Device 4
<--
08/19/22 14:50:07.538 : OPC: Device Target - Device 4
08/19/22 14:50:21.347 : Temperature is 25.2%
08/19/22 14:50:21.348 : Humidity is 21.9%
08/19/22 14:50:36.161 : Getting device health status
08/19/22 14:50:36.501 : Device health status retrieved

```