### PR TITLE
fixes RFN debug being on by default

### DIFF
--- a/global/handlers.lua
+++ b/global/handlers.lua
@@ -656,7 +656,7 @@ function OnWatchedVariableChanged (idDevice, idVariable, strValue)
 end
 
 function ReceivedFromNetwork (idBinding, nPort, strData)
-	local suppressRFN
+	local suppressRFN = not (DEBUG_RFN)
 
 	if (WebSocket) then
 		if (WebSocket.Sockets and WebSocket.Sockets [idBinding]) then


### PR DESCRIPTION
The global `DEBUG_RFN` for ReceivedFromNetwork debug is set to on by default. 

While I think this is appropriate during testing/setup it might not be appropriate for production. There are filters being applied to SSDP and WS but normal network traffic isn't filtered. This can get really chatty when applied through the `HandlerDebug` function especially if the developer has their own debug downstream.