### PR TITLE
Add the code to catch errors inside lua pcall protected functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ Lua files in the `module` directory create an object that can only be accessed b
 - `auth_code_grant.lua` : Setup an OAuth 2 connection using the Authorization Code Grant flow.  Requires an API key to use : contact your Control4 representative for more details.
 - `auth_device_PIN.lua` : Setup an OAuth 2 connection using the PIN Grant flow.  Requires an API key to use : contact your Control4 representative for more details.
 - `json.lua` : Pure Lua implementation of a JSON parser for encode/decode.  Copyright 2010-2017 Jeffrey Friedl, see LICENSE.md for details.
+- `pcall.lua` : Overriding lua pcall function to allow catching errors inside pcall protected functions and sending them to the datalake 
 - `ssdp.lua` : Implements SSDP discovery in pure Driverworks.  Does not register a listening server.
 - `websocket.lua` : Implements a websocket client in pure Driverworks.

--- a/module/pcall.lua
+++ b/module/pcall.lua
@@ -1,0 +1,36 @@
+-- Copyright 2023 Snap One, LLC. All rights reserved.
+
+-- By including this module, lua pcall function will be overriden to allow
+-- logging any encountered errors in the datalake along with the traceback.
+
+-- If the custom error handler is necessary, the 'OnLuaError' function needs 
+-- to be explicitely defined.
+
+COMMON_PCALL_VERSION = 1
+
+do
+    local metrics = require('drivers-common-public.module.metrics'):new()
+    local __pcall = pcall
+    function pcall(f, ...)
+        local output = {__pcall(f, ...)}
+        if not output[1] then
+            __pcall(function()
+                C4:ErrorLog(output[2])
+            end)
+            __pcall(function()
+                C4:ErrorLog(debug.traceback(output[2]))
+            end)
+            __pcall(function()
+                metrics:SetCounter("LuaErrorCount")
+            end)
+            __pcall(function()
+                local data = {}
+                data["message"] = output[2]
+                data["traceback"] = debug.traceback(output[2])
+                metrics:SetJSON("LuaError", C4:JsonEncode(data))
+            end)
+            __pcall(OnLuaError, output[2])
+        end
+        return unpack(output)
+    end
+end


### PR DESCRIPTION
Overriding lua pcall function to allow catching errors inside pcall protected functions and sending them to the datalake