### PR TITLE
Fix for OAuth expires_in header when value is unexpected

### DIFF
--- a/module/auth_code_grant.lua
+++ b/module/auth_code_grant.lua
@@ -369,7 +369,6 @@ function oauth:RefreshToken (contextInfo, newRefreshToken)
 	end
 	self.Timer.RefreshingToken = SetTimer (self.Timer.RefreshingToken, 30 * ONE_SECOND, _timer)
 
-
 	self:urlPost (url, data, headers, 'GetTokenResponse', {contextInfo = contextInfo})
 end
 
@@ -405,7 +404,7 @@ function oauth:GetTokenResponse (strError, responseCode, tHeaders, data, context
 
 		self.SCOPE = data.scope or self.SCOPE
 
-		self.EXPIRES_IN = data.expires_in or self.EXPIRES_IN or self.DEFAULT_EXPIRES_IN
+		self.EXPIRES_IN = tonumber(data.expires_in) or self.EXPIRES_IN or self.DEFAULT_EXPIRES_IN
 
 		if (self.EXPIRES_IN and self.REFRESH_TOKEN) then
 			local _timer = function (timer)
@@ -441,7 +440,6 @@ function oauth:GetTokenResponse (strError, responseCode, tHeaders, data, context
 		print ((self.NAME or 'OAuth') .. ': Access Token denied:', data.error, data.error_description, data.error_uri)
 
 		self:setLink ('')
-
 
 		self.metrics:SetCounter ('AccessTokenDenied')
 		if (data.error) then

--- a/module/auth_device_PIN.lua
+++ b/module/auth_device_PIN.lua
@@ -68,7 +68,7 @@ function oauth:GetPINCodeResponse (strError, responseCode, tHeaders, data, conte
 		self.device_code = data.device_code
 		local user_code = data.user_code
 		local verification_url = data.verification_url
-		local expires_in = data.expires_in or (5 * ONE_MINUTE)
+		local expires_in = tonumber(data.expires_in) or (5 * ONE_MINUTE)
 		local interval = data.interval or 5
 
 		if (self.notifyHandler.PINCodeReceived) then


### PR DESCRIPTION
`oauth:GetTokenResponse()` will fail without error when the `expires_in` value is not a number type as expected. This was noticed when a service returned a value of `31556939` seconds (1 year) and the code would not proceed beyond the compare with `self.MAX_EXPIRES_IN` on restart. 

Putting `tonumber()` on the returned data seems to resolve the issue and a default value is already provided incase `nil` is returned. Included the same fix for PIN authorization with this PR. 