### PR TITLE
Fix memory leak in CancelTimer where Timer table entries are never removed

### DIFF
--- a/global/timer.lua
+++ b/global/timer.lua
@@ -40,10 +40,9 @@ function CancelTimer (timerId)
 		end
 
 		if (timer.Cancel) then
-			Timer [timerId] = timer:Cancel ()
-		else
-			Timer [timerId] = nil
+			timer:Cancel ()
 		end
+		Timer [timerId] = nil
 		TimerFunctions [timer] = nil
 	end
 	return nil


### PR DESCRIPTION
## Summary
Fix memory leak in `CancelTimer` where `Timer` table entries are never removed

## Problem

`CancelTimer` uses `Timer[timerId] = timer:Cancel()` to simultaneously cancel the C4 timer and remove it from the tracking table. This relies on `Cancel()` returning `nil`. Two issues:

1. If `Cancel()` returns any non-nil value, the entry persists instead of being removed.
2. When `CancelTimer` is called with a **userdata** reference (the timer object itself rather than its string ID), `Timer[userdata] = timer:Cancel()` creates a **new orphaned entry** under a userdata key — even though the timer was originally stored under a string key. No subsequent code path ever removes this orphaned entry.

`TimerFunctions` does not have this problem because it already uses explicit `TimerFunctions[timer] = nil`.

## Fix

Separate the `Cancel()` call from the table cleanup so `Timer[timerId] = nil` runs unconditionally:

```lua
-- Before
if (timer.Cancel) then
  Timer [timerId] = timer:Cancel ()
else
  Timer [timerId] = nil
end

-- After
if (timer.Cancel) then
  timer:Cancel ()
end
Timer [timerId] = nil
```

That's the entire fix. No other files are changed.

## Test plan

- Verify `CancelTimer("stringId")` removes `Timer["stringId"]` after cancel
- Verify `CancelTimer(userdataRef)` does not create an orphaned `Timer[userdata]` entry
- Verify one-shot timer expiry leaves no residual entries in `Timer` or `TimerFunctions`
- Verify repeating timers are unaffected (cleanup path is skipped for `repeating == true`)